### PR TITLE
fix: replace static delay with a check for published items before redirect to updated collections

### DIFF
--- a/src/interface/collections/index.jsx
+++ b/src/interface/collections/index.jsx
@@ -221,3 +221,25 @@ export const addPrivateCollection = async (
   const data = await response.data;
   return data;
 };
+
+export const checkResponseStatus = async (collectionId, items, url, counter=0) => {
+  // get the item id from the first item to check if it exists on the backend
+  const itemId = Object.keys(items)[0];
+  const itemUrl = new URL(path.join(stacPath, collectionId, itemsPath, itemId), backendUrl).toString();
+
+  // tries to fetch the item by id, with a 1 second pause, 10 times before timingout 
+  try {
+    const response = await fetch(itemUrl);
+    if (response.status === 200) {
+      window.open(url, "_blank");
+    } else if (counter < 10) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      counter += 1;
+      await checkResponseStatus(collectionId, items, url, counter);
+    } else {
+      throw new Error('Timeout error');
+    }
+  } catch (error) {
+    console.error("An error occurred:", error);
+  }
+};

--- a/src/pages/LoadLocal/LoadLocal.jsx
+++ b/src/pages/LoadLocal/LoadLocal.jsx
@@ -34,7 +34,7 @@ import {
   groupFilesByID,
   generateSTAC,
 } from "./utils";
-import { addItemsToCollection } from "interface/collections";
+import { addItemsToCollection, checkResponseStatus } from "interface/collections";
 
 // Url paths
 import { stacApiBrowserUrl, collectionsPath } from '../../utils/paths.jsx'
@@ -174,14 +174,11 @@ const LoadLocal = () => {
     }
     await addItemsToCollection(selectedCollection, stac);
 
-    // Wait for 2 seconds and then redirect to collection
+    // url to the updated collection
     const url = new URL(path.join(collectionsPath, selectedCollection.id), stacApiBrowserUrl).toString();
-    setTimeout(() => {
-      window.open(
-        url,
-        "_blank"
-      );
-    }, 2000);
+
+    // checks the status of the items being published to the collection and redirects once the items are published
+    await checkResponseStatus(selectedCollection.id, stac, url)
   };
 
   return (


### PR DESCRIPTION
Created checkResponseStatus() function which tries to fetch one of the items being published, by id.
A 200 response, redirects the user to the collection's url
A 1 second delay is applied between attempting to fetch the item and a counter has been set to only allow this to happen 10 times before returning a timeout error