### PR TITLE
feat: add my details page and dropdown user icon

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 // React
-import { useEffect } from "react";
+import { useEffect, useState, createContext } from "react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 
 // Layout components
@@ -13,8 +13,25 @@ import STAClogo from "assets/images/logo.png";
 
 // Styles
 import "./assets/styles/base.scss";
+import { auth } from "auth/auth";
+
+export const UserDataContext = createContext();
 
 export default function App() {
+
+  const [userData, setUserData] = useState(null);
+
+  // getting the user data and setting it to the state
+  useEffect(() => {
+    async function getUserData() {
+      let userData = await auth();
+      console.log(userData);
+      setUserData(userData);
+      }
+  
+      getUserData();
+  }, []);
+  
   const { pathname } = useLocation();
 
   // Setting page scroll to 0 when changing the route
@@ -44,7 +61,8 @@ export default function App() {
     });
 
   return (
-    <>
+    // passing the userData in the context
+    <UserDataContext.Provider value={[userData, setUserData]}>
       <Sidenav brand={STAClogo} brandName="STAC Portal" routes={routes} />
       <div
         style={{
@@ -68,6 +86,6 @@ export default function App() {
           </Routes>
         </div>
       </div>
-    </>
+    </UserDataContext.Provider >
   );
 }

--- a/src/assets/styles/base.scss
+++ b/src/assets/styles/base.scss
@@ -150,7 +150,7 @@ overline {
     }
   }
 
-  &-update {
+  &-update, &-refresh {
     background-color: var(--osweb-color-primary);
     color: #fff;
     cursor: pointer;

--- a/src/auth/auth.js
+++ b/src/auth/auth.js
@@ -1,7 +1,46 @@
 // Modules
 import axios from "axios";
 
-const getAADToken = async () => {
+// adds user's profile picture to their data object
+const addProfilePicture = async (userData) => {
+
+  const accessToken = userData.access_token;
+
+  try {
+    const response = await fetch('https://graph.microsoft.com/v1.0/me/photo/$value', {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`
+      }
+    });
+
+    if (!response.ok) {
+      userData.picture = 'no-picture.jpg';
+      return userData;
+    }
+
+    const blob = await response.blob();
+    const picture = URL.createObjectURL(blob);
+
+    userData.picture = picture;
+    return userData;
+
+  } catch (error) {
+    console.error(error);
+    throw new Error('Failed to retrieve profile picture');
+  }
+};
+
+// returns the dev data object when in development
+const getDevData = () => {
+  // paste in your own user data to test or use the dev default
+  const data = {"access_token":"000","user_claims":[{"typ":"name","val":"Dev User"},{"typ":"roles","val":".Developer"}],"user_id":"Dev User"};
+  return data;
+};
+
+// returns the user data object when in production
+const getAADData = async () => {
+
   try {
     const instance = axios.create();
 
@@ -21,8 +60,7 @@ const getAADToken = async () => {
       }
 
       const newTokenResponse = await instance.get("/.auth/me");
-      const { id_token } = newTokenResponse.data[0];
-      return id_token;
+      return newTokenResponse.data[0];  // returns the whole user data object
     }
 
     // Implies we are localhost
@@ -34,17 +72,32 @@ const getAADToken = async () => {
   }
 
   window.location.href = "/.auth/login/aad";
+
   return null;
 };
 
+// returns the user data object with the profile picture included
 const auth = async () => {
+
+  // if in development, return the dev data object
+  if (process.env.NODE_ENV !== 'production'){
+    console.log('dev mode')
+    return addProfilePicture(getDevData());  
+  }
+
+  // if in production, return the user data object
   axios.interceptors.request.use(async (config) => {
-    const token = await getAADToken();
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
+    
+    console.log('prod mode')
+    const userData = await getAADData();
+    userData = addProfilePicture(userData);
+
+    const { id_token } = userData;
+    if (userData) {
+      config.headers.Authorization = `Bearer ${id_token}`;
     }
-    return config;
+    return userData  // config;
   });
 };
 
-export { getAADToken, auth };
+export { auth };

--- a/src/components/Breadcrumbs/UserIconButton.jsx
+++ b/src/components/Breadcrumbs/UserIconButton.jsx
@@ -1,0 +1,72 @@
+// React
+import React, { useEffect, useState, useContext } from "react";
+
+// Context
+import { UserDataContext } from "App";
+
+// @mui components
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import IconButton from '@mui/material/IconButton';
+import { Avatar } from "@mui/material";
+
+// Styles
+import "./style.scss";
+
+
+// User icon with dropdown menu
+export const IconButtonWithDropdown = () => {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [userPicture, setUserPicture] = useState('');
+  const [userName, setUserName] = useState('');
+
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const [userDetails] = useContext(UserDataContext);
+
+  useEffect(() => {
+    async function fetchData() {
+      let userPicture = userDetails.picture;
+      let userName = userDetails.user_claims.find(item => item.typ === 'name').val;
+      setUserName(userName);
+      setUserPicture(userPicture);
+      }
+  
+      fetchData();
+  });
+
+  return (
+    <div className="breadcrumbs__container">
+      <IconButton
+        className = "breadcrumbs-button"
+        aria-controls="dropdown-menu"
+        aria-haspopup="true"
+      >
+        <Avatar
+          alt = {userName}
+          src = {userPicture}
+          className = "breadcrumbs-avatar"
+          onClick={handleClick}
+        />
+      </IconButton>
+      <Menu
+        id="dropdown-menu"
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem onClick={() => (window.location.href = "/my-details")}>My Details</MenuItem>
+        <MenuItem onClick={() => (window.location.href = "/.auth/logout")}>
+          Logout
+        </MenuItem>
+      </Menu>
+    </div>
+  );
+};

--- a/src/components/Breadcrumbs/index.js
+++ b/src/components/Breadcrumbs/index.js
@@ -1,12 +1,12 @@
 // @mui components
 import { Home, ChevronRight } from "@mui/icons-material";
 
-// Icons
-import LogoutIcon from "@mui/icons-material/Logout";
-import CustomWidthTooltip from "components/Tooltip/CustomWidthTooltip";
+// Dropdown menu button
+import { IconButtonWithDropdown } from "./UserIconButton";
 
 // Styles
 import "./style.scss";
+
 
 const Breadcrumbs = ({ page }) => {
   return (
@@ -25,18 +25,7 @@ const Breadcrumbs = ({ page }) => {
           <span className="breadcrumbs__container__item__text">{page}</span>
         </div>
       </div>
-      <div className="breadcrumbs__container">
-        <CustomWidthTooltip title="Logout" placement="bottom" arrow>
-          <LogoutIcon
-            style={{
-              marginRight: "5px",
-              color: "#e18080",
-              cursor: "pointer",
-            }}
-            onClick={() => (window.location.href = "/.auth/logout")}
-          />
-        </CustomWidthTooltip>
-      </div>
+      <IconButtonWithDropdown />
     </div>
   );
 };

--- a/src/components/Breadcrumbs/style.scss
+++ b/src/components/Breadcrumbs/style.scss
@@ -4,7 +4,7 @@
   justify-content: space-between;
 
   & svg {
-    color:  #453C90!important;
+    color:  var(--osweb-color-primary) !important;
   }
 
   &__container {
@@ -38,5 +38,17 @@
         margin-left: 0.5em;
       }
     }
-  }
+
+    & .breadcrumbs-button {
+      height: 2.5rem;
+      width: 2.5rem;
+
+      & .breadcrumbs-avatar{
+        background-color: var(--osweb-color-primary) !important;
+        & svg {
+          color:  #fff !important;
+        }
+      }
+    }
+  } 
 }

--- a/src/components/MDButton/index.js
+++ b/src/components/MDButton/index.js
@@ -1,5 +1,5 @@
 // @mui components
-import { Add, Delete, Edit } from "@mui/icons-material";
+import { Add, Delete, Edit, Refresh} from "@mui/icons-material";
 
 const MDButton = ({
   children,
@@ -25,6 +25,7 @@ const MDButton = ({
           {buttonType === "create" && <Add />}
           {buttonType === "delete" && <Delete />}
           {buttonType === "update" && <Edit />}
+          {buttonType === "refresh" && <Refresh />}
         </span>
       )}
       {children}

--- a/src/index.js
+++ b/src/index.js
@@ -9,11 +9,6 @@ import App from "./App";
 // Styles
 import './index.scss';
 
-// Auth
-import { auth } from "auth/auth";
-if (process.env.NODE_ENV === 'production') {
-  auth();
-}
 
 ReactDOM.render(
   <BrowserRouter>

--- a/src/pages/DisplayMyDetails/DisplayMyDetails.jsx
+++ b/src/pages/DisplayMyDetails/DisplayMyDetails.jsx
@@ -1,0 +1,140 @@
+// React
+import React, { useEffect, useState, useContext } from "react";
+
+// @mui components
+import Grid from "@mui/material/Grid";
+import Card from "@mui/material/Card";
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import IconButton from '@mui/material/IconButton';
+import { ContentCopy } from "@mui/icons-material";
+
+// Layout components
+import DashboardLayout from "layout/LayoutContainers/DashboardLayout";
+
+// STAC Portal components
+import MDBox from "components/MDBox";
+import MDTypography from "components/MDTypography";
+import MDButton from "components/MDButton";
+
+// Interface
+import { Avatar } from "@mui/material";
+
+// Context
+import { UserDataContext } from "App";
+
+// Styles
+import "./style.scss";
+
+// set up the display of the user's details
+const DisplayMyDetails = () => {
+
+  const [userName, setUserName] = useState('');
+  const [userRole, setUserRole] = useState('');
+  const [userPicture, setUserPicture] = useState('');
+  const [userDetails] = useContext(UserDataContext);
+  
+  useEffect(() => {
+    // getting the user's name and role from the user_claims array
+    async function getValueByType(list, valueType) {
+      if (list && list.length > 0){
+        const value = list.find(item => item.typ === valueType);
+        return value ? value.val : '';
+      }  
+    }
+  
+    async function fetchData() {
+      // getting the user's name, role and picture from the userDetails object
+      const userDetailsList = userDetails.user_claims;
+      let userName = await getValueByType(userDetailsList, 'name');
+      let userRole = await getValueByType(userDetailsList, 'roles');
+      let userPicture;
+      if (userDetails.picture){
+        userPicture = userDetails.picture;
+      };
+      if (userRole){
+        userRole = userRole.split('.')[1];
+      }
+
+      setUserName(userName);
+      setUserRole(userRole);
+      setUserPicture(userPicture);
+    }
+    
+    fetchData();
+  }, [userDetails]);
+
+  // placeholder until functionality for providing API keys is ready
+  let apiKey = '00000000000000000000000000000000';  
+
+  return (
+    <DashboardLayout>
+      <MDBox>
+        <Grid container spacing={0.5}>
+          <Grid item xs={12}>
+            <Card className="card-title">
+              <MDBox>
+                <MDTypography variant="h4">My Details</MDTypography>
+              </MDBox>
+            </Card>
+            <Grid item xs={12} className="my-details-container">
+              <Card
+                className="my-details-card"
+              >
+                <Grid
+                className="my-details-grid"
+                >
+                  <Avatar
+                    alt = {userName}
+                    src= {userPicture}
+                    className="avatar"
+                  />
+                </Grid>
+                <Grid
+                  className="my-details-grid"
+                >
+                  <List
+                    className="my-details-list"
+                  >
+                    <ListItem>
+                      <MDTypography variant="h4">Name:</MDTypography>
+                      <span class="my-details-item">{userName}</span>
+                    </ListItem>
+                    <ListItem>
+                      <MDTypography variant="h4">Role:</MDTypography>
+                      <span class="my-details-item">{userRole}</span>
+                    </ListItem>
+                    <ListItem>
+                      <MDTypography variant="h4">API Key:</MDTypography>
+                      <span id="api-key" class="my-details-item">{apiKey.slice(0, 7)}...</span>
+                      <IconButton
+                        className='copy-api-key-button'
+                        title="Copy API Key to clipboard"
+                      >
+                        <ContentCopy
+                          className='copy-api-key-icon' 
+                          onClick={() =>  navigator.clipboard.writeText(apiKey)}
+                        />
+                      </IconButton>
+                    </ListItem>
+                    <ListItem>
+                      <MDButton
+                        buttonType="refresh"
+                        className="btn-full-width"
+                        // onClick={handleRefreshAPIKey}  // functionality to be added
+                      >
+                        Refresh API Key
+                      </MDButton>
+                    </ListItem>                  
+                  </List>
+                </Grid>
+              </Card>
+            </Grid>
+          </Grid>
+        </Grid>
+      </MDBox>
+    </DashboardLayout>
+  );
+};
+
+export { DisplayMyDetails };

--- a/src/pages/DisplayMyDetails/style.scss
+++ b/src/pages/DisplayMyDetails/style.scss
@@ -1,0 +1,57 @@
+.my-details-container{
+  max-width: 50vw !important;
+  margin: 0 auto !important;
+
+  & .my-details-card {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    margin: 2rem;
+    height: 60vh;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-around;
+
+    & .my-details-grid{
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+
+      & .avatar {
+        width: 30vh !important;
+        height: 30vh !important;
+        font-size: 15vh !important;
+        background-color: var(--osweb-color-primary) !important;
+      }
+      
+      & .my-details-list {
+        height: 30vh;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-evenly;
+
+        & .my-details-item {
+          margin-left: 8px;
+          font-size: 20px;
+        }
+
+        & .copy-api-key-button {
+          &:hover {
+            background-color: #fff !important;
+          }
+          
+          & .copy-api-key-icon {
+            color: var(--osweb-color-primary);
+          
+            &:hover {
+              color: #FF5F00 !important;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/src/routes.js
+++ b/src/routes.js
@@ -8,6 +8,7 @@ import LoadStatuses from "pages/LoadStatuses/LoadStatuses";
 import DisplayCollections from "pages/DisplayCollections/DisplayCollections";
 import PublicCatalogs from "pages/PublicCatalogs/PublicCatalogs";
 import AddPrivateCollection from "pages/AddPrivateCollection/AddPrivateCollection";
+import { DisplayMyDetails } from "pages/DisplayMyDetails/DisplayMyDetails";
 
 // @mui icons
 import {
@@ -116,6 +117,15 @@ const routes = [
     key: "stac-browser",
     icon: <Explore />,
     href: process.env.REACT_APP_PORTAL_STAC_API_BROWSER_URL,
+  },
+
+  {
+    type: "hidden",
+    name: "My Details",
+    key: "my-details",
+    route: "/my-details",
+    component: <DisplayMyDetails/>,
+
   },
 ];
 


### PR DESCRIPTION
Added My Detail page, user icon which has a dropdown menu for My Detail and Logout options
Used React's useContext to set the user's details once the app starts so that it doesnt need to be retrieved everytime some user details are needed.
The user icon in the top right hand corner displays the user's profile image (if present) when on any page on the site and if its not present, it displays the user's first initial.
When in development, a dummy set of data is retrieved instead so that the My Details page is still functional and no unnecessary auth me requests are made