### PR TITLE
fix: make sidenav responsive for mobile screens

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -52,15 +52,8 @@ export default function App() {
           flexDirection: "column",
         }}
       >
-        {/* The sidenav takes 300px, so use rest of the screen */}
         <div
-          style={{
-            flex: "1 1 auto",
-            marginLeft: "300px",
-            padding: "1rem",
-            width: "calc(100% - 330px)",
-            height: "100%",
-          }}
+          id="content-display"
         >
           <Routes>
             {getRoutes(routes)}

--- a/src/assets/styles/base.scss
+++ b/src/assets/styles/base.scss
@@ -239,3 +239,18 @@ overline {
 .table-toolbar {
   box-shadow: none !important;
 }
+
+#content-display{
+  flex: 1 1 auto;
+  margin-left: 300px;  // The sidenav takes 300px, so use rest of the screen
+  padding: 1rem;
+  width: calc(100% - 330px);
+  height: 100%;
+}
+
+// adapts display content size for mobile
+.mobile-display{
+  padding-top: 3rem !important;
+  margin: 0.5em !important;
+  width: auto !important;
+}

--- a/src/assets/styles/base.scss
+++ b/src/assets/styles/base.scss
@@ -8,6 +8,10 @@ body {
   background-color: #f0f2f5;
 }
 
+#root {
+  position: relative;
+}
+
 h4 {
   font-weight: 700;
   // Nice heading
@@ -243,14 +247,13 @@ overline {
 #content-display{
   flex: 1 1 auto;
   margin-left: 300px;  // The sidenav takes 300px, so use rest of the screen
-  padding: 1rem;
+  padding: 1rem 0;
   width: calc(100% - 330px);
   height: 100%;
 }
 
 // adapts display content size for mobile
 .mobile-display{
-  padding-top: 3rem !important;
   margin: 0.5em !important;
   width: auto !important;
 }

--- a/src/components/Breadcrumbs/index.js
+++ b/src/components/Breadcrumbs/index.js
@@ -10,6 +10,7 @@ import "./style.scss";
 
 const Breadcrumbs = ({ page }) => {
   return (
+    <>
     <div className="breadcrumbs">
       <div className="breadcrumbs__container">
         <div
@@ -27,6 +28,10 @@ const Breadcrumbs = ({ page }) => {
       </div>
       <IconButtonWithDropdown />
     </div>
+    <div>
+      <hr id="mobile-nav-hr"></hr>
+    </div>
+    </>
   );
 };
 

--- a/src/components/Breadcrumbs/style.scss
+++ b/src/components/Breadcrumbs/style.scss
@@ -1,5 +1,4 @@
 .breadcrumbs {
-  margin-bottom: 4em;
   display:flex;
   justify-content: space-between;
 
@@ -51,4 +50,28 @@
       }
     }
   } 
+}
+
+#mobile-nav-hr {
+  display: none;  // toggle remove for mobile view
+  width: 100%;
+  margin: 1em 0 !important;
+  border: none;
+  opacity: 1;
+  background-color: var(--osweb-color-primary);
+  background-image: none !important;
+}
+
+@media (max-width: 768px) {
+  #mobile-nav-hr {
+    display: block;
+  }
+
+  .breadcrumbs{
+    justify-content: space-between !important;
+    margin-left: 5rem !important;  // leaves room for the burger menu icon
+    &__container {
+      margin-bottom: 0;
+    }
+  }
 }

--- a/src/components/Sidenav/SidenavRoot.js
+++ b/src/components/Sidenav/SidenavRoot.js
@@ -9,7 +9,7 @@ export default styled(Drawer)(() => {
       background: "linear-gradient(180deg, #453C90 0%, #191636 100%)",
       margin: "1em",
       width: "220px",
-      height: "calc(90vh)",
+      height: "auto",
       borderRadius: "10px",
       overflowX: "hidden",
       transform: "translateX(10px)",

--- a/src/components/Sidenav/SidenavRoot.js
+++ b/src/components/Sidenav/SidenavRoot.js
@@ -9,7 +9,7 @@ export default styled(Drawer)(() => {
       background: "linear-gradient(180deg, #453C90 0%, #191636 100%)",
       margin: "1em",
       width: "220px",
-      height: "auto",
+      height: "calc(100vh - 4em)",
       borderRadius: "10px",
       overflowX: "hidden",
       transform: "translateX(10px)",

--- a/src/components/Sidenav/index.js
+++ b/src/components/Sidenav/index.js
@@ -7,6 +7,7 @@ import { useLocation, NavLink } from "react-router-dom";
 // @mui material components
 import List from "@mui/material/List";
 import Link from "@mui/material/Link";
+import Drawer from "@mui/material/Drawer";
 
 // material icons
 import MenuIcon from '@mui/icons-material/Menu';
@@ -25,7 +26,7 @@ import MDButton from "components/MDButton";
 function Sidenav({ color, brand, brandName, routes, ...rest }) {
   const location = useLocation();
   const collapseName = location.pathname.replace("/", "");
-  // adding in a state for whether the sidenav should be collapsed or not (for mobile)
+  // sets the state for mobile screen or not based on screen width
   const mobileScreenSize = 768;
   const [mobileSidenav, setMobileSidenav] = useState(document.documentElement.clientWidth <= mobileScreenSize);
   const [hideMobileNav, setHideMobileNav] = useState(true);
@@ -38,7 +39,7 @@ function Sidenav({ color, brand, brandName, routes, ...rest }) {
       setHideMobileNav(document.documentElement.clientWidth <= mobileScreenSize);
     };
   
-    // Set initial state
+    // sets initial states
     setMobileSidenav(document.documentElement.clientWidth <= mobileScreenSize); 
     setHideMobileNav(document.documentElement.clientWidth <= mobileScreenSize);
   
@@ -49,7 +50,7 @@ function Sidenav({ color, brand, brandName, routes, ...rest }) {
     };
   }, []);
 
-  // if the screen is mobile size add the mobile-display class to the element with id="content-display"
+  // if the screen is mobile size, add the mobile-display class to the element with id="content-display"
   useEffect(() => {
     const displayElement = document.getElementById("content-display");
     if (mobileSidenav) {
@@ -84,7 +85,7 @@ function Sidenav({ color, brand, brandName, routes, ...rest }) {
             />
           </Link>
         ) : (
-          // when a link is clicked the link list is hidden if the screen is mobile size
+          // on click for closing the mobile sidenav once a link is selected
           <NavLink key={key} to={route} onClick={() => setHideMobileNav=mobileSidenav}>
             <SidenavCollapse
               name={name}
@@ -124,7 +125,29 @@ function Sidenav({ color, brand, brandName, routes, ...rest }) {
     }
   );
 
-  return(
+  if (mobileSidenav) {
+    return (
+      <MDBox className="mobile-sidenav">
+        <MDButton
+          className="mobile-sidenav__menu-button"
+          onClick={() => setHideMobileNav(!hideMobileNav)}
+        >
+          <MenuIcon className="mobile-sidenav__menu-icon"></MenuIcon>
+        </MDButton>
+        <Drawer
+          anchor="left"
+          open={!hideMobileNav}
+          onClose={() => setHideMobileNav(true)}
+          className="mobile-sidenav__container"
+        >
+          <MDBox to="/" className="mobile-sidenav__container-content">
+            {<List>{renderRoutes}</List>}
+          </MDBox>
+        </Drawer>
+      </MDBox>
+    );
+  } else {
+    return (
       <SidenavRoot variant="permanent" className="root-sidenav">
         <MDBox>
           <MDBox to="/" className="sidenav-brand-container">  
@@ -133,21 +156,11 @@ function Sidenav({ color, brand, brandName, routes, ...rest }) {
             </a>
           </MDBox>
         </MDBox>
-          {/* button for toggling the mobile menu */}
-          {mobileSidenav && (
-            <MDBox>
-              <MDButton
-                className="mobile-menu-button"
-                onClick={() => setHideMobileNav(!hideMobileNav)}
-              >
-                <MenuIcon className="mobile-menu-icon"></MenuIcon>
-              </MDButton>
-            </MDBox>
-          )}
         {!hideMobileNav && <hr></hr>}
         {!hideMobileNav && <List>{renderRoutes}</List>}
       </SidenavRoot>
-  );
+    )
+  }
 }
 
 export default Sidenav;

--- a/src/components/Sidenav/index.js
+++ b/src/components/Sidenav/index.js
@@ -94,6 +94,27 @@ function Sidenav({ color, brand, brandName, routes, ...rest }) {
             />
           </NavLink>
         );
+      } else if (title === "OS Catalog" && mobileSidenav) {  // no top padding only for first title in mobile sidenav
+        returnValue = (
+          <MDTypography
+            key={key}
+            display="block"
+            variant="span"
+            fontWeight="bold"
+            textTransform="uppercase"
+            color="white"
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              textTransform: "uppercase",
+              fontSize: "0.75rem",
+              marginBottom: "0.4rem",
+              marginLeft: "1rem",
+            }}
+          >
+            {title}
+          </MDTypography>
+        );
       } else if (type === "title") {
         returnValue = (
           <MDTypography

--- a/src/components/Sidenav/index.js
+++ b/src/components/Sidenav/index.js
@@ -1,9 +1,15 @@
+// React
+import { useState, useEffect } from "react";
+
 // react-router-dom components
 import { useLocation, NavLink } from "react-router-dom";
 
 // @mui material components
 import List from "@mui/material/List";
 import Link from "@mui/material/Link";
+
+// material icons
+import MenuIcon from '@mui/icons-material/Menu';
 
 // STAC Portal components
 import MDBox from "components/MDBox";
@@ -14,10 +20,45 @@ import SidenavCollapse from "components/Sidenav/SidenavCollapse";
 
 // Custom styles for the Sidenav
 import SidenavRoot from "components//Sidenav/SidenavRoot";
+import MDButton from "components/MDButton";
 
 function Sidenav({ color, brand, brandName, routes, ...rest }) {
   const location = useLocation();
   const collapseName = location.pathname.replace("/", "");
+  // adding in a state for whether the sidenav should be collapsed or not (for mobile)
+  const mobileScreenSize = 768;
+  const [mobileSidenav, setMobileSidenav] = useState(document.documentElement.clientWidth <= mobileScreenSize);
+  const [hideMobileNav, setHideMobileNav] = useState(true);
+
+  // sets mobileSidenav to true/false depending on the window size
+  useEffect(() => {
+    const handleResize = () => {
+      console.log(document.documentElement.clientWidth);
+      setMobileSidenav(document.documentElement.clientWidth <= mobileScreenSize);
+      setHideMobileNav(document.documentElement.clientWidth <= mobileScreenSize);
+    };
+  
+    // Set initial state
+    setMobileSidenav(document.documentElement.clientWidth <= mobileScreenSize); 
+    setHideMobileNav(document.documentElement.clientWidth <= mobileScreenSize);
+  
+    window.addEventListener('resize', handleResize);
+  
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  // if the screen is mobile size add the mobile-display class to the element with id="content-display"
+  useEffect(() => {
+    const displayElement = document.getElementById("content-display");
+    if (mobileSidenav) {
+      displayElement.classList.add("mobile-display");
+    } else {
+      displayElement.classList.remove("mobile-display");
+    }
+
+  }, [mobileSidenav]);
 
   const renderRoutes = routes.map(
     ({ type, name, icon, title, key, href, route }) => {
@@ -43,7 +84,8 @@ function Sidenav({ color, brand, brandName, routes, ...rest }) {
             />
           </Link>
         ) : (
-          <NavLink key={key} to={route}>
+          // when a link is clicked the link list is hidden if the screen is mobile size
+          <NavLink key={key} to={route} onClick={() => setHideMobileNav=mobileSidenav}>
             <SidenavCollapse
               name={name}
               icon={icon}
@@ -82,20 +124,29 @@ function Sidenav({ color, brand, brandName, routes, ...rest }) {
     }
   );
 
-  return (
-    <SidenavRoot {...rest} variant="permanent">
-      <MDBox>
-        <MDBox to="/" className="sidenav-brand-container">
-          {brand && (
+  return(
+      <SidenavRoot variant="permanent" className="root-sidenav">
+        <MDBox>
+          <MDBox to="/" className="sidenav-brand-container">  
             <a href="/">
               <img src={brand} alt="brand" className="sidenav-brand" />
             </a>
-          )}
+          </MDBox>
         </MDBox>
-      </MDBox>
-      <hr></hr>
-      <List>{renderRoutes}</List>
-    </SidenavRoot>
+          {/* button for toggling the mobile menu */}
+          {mobileSidenav && (
+            <MDBox>
+              <MDButton
+                className="mobile-menu-button"
+                onClick={() => setHideMobileNav(!hideMobileNav)}
+              >
+                <MenuIcon className="mobile-menu-icon"></MenuIcon>
+              </MDButton>
+            </MDBox>
+          )}
+        {!hideMobileNav && <hr></hr>}
+        {!hideMobileNav && <List>{renderRoutes}</List>}
+      </SidenavRoot>
   );
 }
 

--- a/src/components/Sidenav/style.scss
+++ b/src/components/Sidenav/style.scss
@@ -122,11 +122,41 @@
   }
 }
 
-.mobile-menu-button {
-  background-color: #fff !important;
-  margin: auto;
-
-  & .mobile-menu-icon {
+.mobile-sidenav {
+  &__menu-button {
+    background-color: #f0f2f5 !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+    width: 60px !important;
+    min-width: 60px !important;
+    position: absolute;
+    top: 2rem;
+    left: 0;
+  }
+  
+  &__menu-icon {
     color: var(--osweb-color-primary) !important;
+    width: 40px !important;
+    height: 40px !important;
+    margin: 0 auto;
+  }
+  
+  &__container{
+    & .css-4t3x6l-MuiPaper-root-MuiDrawer-paper {
+      background: linear-gradient(180deg, #453C90 0%, #191636 100%) !important;
+      padding: 1em !important;
+      width: auto !important;
+      height: auto !important;
+    }
+  
+    &__container-content{
+      border: none;
+      background: linear-gradient(180deg, #453C90 0%, #191636 100%);
+      width: auto;
+      height: auto;
+      border-radius: 10px;
+      padding: 1em;
+      overflow-y: scroll;
+    }
   }
 }

--- a/src/components/Sidenav/style.scss
+++ b/src/components/Sidenav/style.scss
@@ -146,7 +146,8 @@
       background: linear-gradient(180deg, #453C90 0%, #191636 100%) !important;
       padding: 1em !important;
       width: auto !important;
-      height: auto !important;
+      height: 100vh !important;
+      border-radius: 0 !important;
     }
   
     &__container-content{

--- a/src/components/Sidenav/style.scss
+++ b/src/components/Sidenav/style.scss
@@ -121,3 +121,12 @@
     }
   }
 }
+
+.mobile-menu-button {
+  background-color: #fff !important;
+  margin: auto;
+
+  & .mobile-menu-icon {
+    color: var(--osweb-color-primary) !important;
+  }
+}


### PR DESCRIPTION
Add responsiveness to the sidenav so that it collapses to a button, which can toggle the list of options, on mobile screen and the content of the page adapts to fill the screen.